### PR TITLE
Fix searching with undefined: prefix

### DIFF
--- a/tags/tags.go
+++ b/tags/tags.go
@@ -22,6 +22,8 @@ func detectTagType(s *string) (typ common.TagType) {
 	i := strings.IndexByte(*s, ':')
 	if i != -1 {
 		switch (*s)[:i] {
+		case "undefined":
+			typ = common.Undefined
 		case "artist", "author":
 			typ = common.Author
 		case "series", "copyright":


### PR DESCRIPTION
I should write tests at some point so I stop accidentally breaking things.